### PR TITLE
Turn on the printout of the WRF noise parameter for regression test fv3_gsd_diag3d_debug

### DIFF
--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -467,6 +467,10 @@ export IAU_DRYMASSFIXER=.false.
 # Regional
 export WRITE_RESTART_WITH_BCS=.false.
 
+# Diagnostics
+export PRINT_DIFF_PGR=.false.
+
+# Coupling
 export coupling_interval_fast_sec=0
 }
 

--- a/tests/parm/gsd.nml.IN
+++ b/tests/parm/gsd.nml.IN
@@ -208,6 +208,7 @@
        do_gsl_drag_tofd     = @[DO_GSL_DRAG_TOFD]
        do_ugwp_v1           = @[DO_UGWP_V1]
        do_ugwp_v1_orog_only = @[DO_UGWP_V1_OROG_ONLY]
+       print_diff_pgr       = @[PRINT_DIFF_PGR]
 /
 
 &gfdl_cloud_microphysics_nml

--- a/tests/tests/fv3_gsd_diag3d_debug
+++ b/tests/tests/fv3_gsd_diag3d_debug
@@ -99,5 +99,7 @@ export LSM=3
 export LSOIL_LSM=9
 export KICE=9
 
+export PRINT_DIFF_PGR=.true.
+
 export WLCLK=30
 


### PR DESCRIPTION
As the title says. Can you please merge this into your branch to update your PR? I ran the regression tests against the existing baselines including this change, and they all passed (on Hera with Intel and GNU). Thanks!